### PR TITLE
Condenser temperature is a signed value

### DIFF
--- a/heatpump.yaml
+++ b/heatpump.yaml
@@ -194,7 +194,7 @@ sensor:
     id: "${devicename}_condesor_temperature_t3"
     register_type: holding
     address: 0x6a
-    value_type: U_WORD
+    value_type: S_WORD
     unit_of_measurement: "°C"
   # Register: 107
   - platform: modbus_controller


### PR DESCRIPTION
The condenser temperature under register 0x6a is a signed value, as it will dip down below 0C whenever the outside temperature is low. Treating this as an unsigned value means that -1C shows up as 65535C, which is how I noticed the error.

I've tested this on my Midea Heat Pump over the last couple of weeks and it works without issue.