### PR TITLE
Removed wifi ssid and password from the configuration

### DIFF
--- a/heatpump.yaml
+++ b/heatpump.yaml
@@ -47,10 +47,6 @@ ota:
 
 wifi:
   power_save_mode: none
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-
-  # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
     ssid: "${devicename}-setup"
     password: "heatpump"


### PR DESCRIPTION
This removes the requirement of hard-coded WiFi credentials inside of `secrets.yaml`.
This will now always create an AP for first-time setup.