### PR TITLE
Changed arduino core to esp-idf

### DIFF
--- a/heatpump.yaml
+++ b/heatpump.yaml
@@ -29,7 +29,7 @@ esphome:
 esp32:
   board: esp32dev
   framework:
-    type: arduino
+    type: esp-idf
 
 # Enable logging
 logger:


### PR DESCRIPTION
Changed the framework from `arduino` to `esp-idf` based on performance evaluations.
The switch to `esp-idf` offers increased stability and reduced memory usage