### PR TITLE
Update heatpump.yaml of Register: 0 to be fully configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.1] - 2024-10-15
 
+- Update Register: 0 to be fully configurable
+  
 ## [4.1.0] - 2024-10-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Midea heat pump (and clones) ESPHome
 
-The Midea heat pump and clones like [Airwell](https://www.airwell.com/en/), [Artel](https://www.artelgroup.com/products-heat-pumps/), [Ferroli](https://www.ferroli.com/int/products/hydronic-heat-pumps-cooling-heating-dhw), [Kaisai](https://www.kaisaisystems.nl), [Inventor](https://www.inventorairconditioner.com/heat-pumps-split-monoblock/split-type-heat-pumps/matrix-split-type), [Kaysun](https://www.kaysun.es/en/products-kaysun/aquantia/) can be managed using the Modbus protocol. This project contains configuration file(s) which can be placed on an ESPHome enabled device to communicatie using modbus with the heat pump.
+The Midea heat pump and clones like [Airwell](https://www.airwell.com/en/), [Artel](https://www.artelgroup.com/products-heat-pumps/), [Ferroli](https://www.ferroli.com/int/products/hydronic-heat-pumps-cooling-heating-dhw), [Kaisai](https://www.kaisaisystems.nl), [Inventor](https://www.inventorairconditioner.com/heat-pumps-split-monoblock/split-type-heat-pumps/matrix-split-type), [Kaysun](https://www.kaysun.es/en/products-kaysun/aquantia/), [YORK](https://www.pompycieplayork.pl/produkty/) can be managed using the Modbus protocol. This project contains configuration file(s) which can be placed on an ESPHome enabled device to communicatie using modbus with the heat pump.
 
 <span style="color: red;">**See below for a ready-made ESPHome compatible heatpump controller!!**</span>
 

--- a/heatpump.yaml
+++ b/heatpump.yaml
@@ -7,6 +7,10 @@ globals:
     type: uint16_t
     restore_value: true
     # initial_value: '0'
+  - id: unmasked_value_register_5
+    type: uint16_t
+    restore_value: true
+    # initial_value: '0'    
   - id: unmasked_value_water_temperature_t1s
     type: uint16_t
     restore_value: no
@@ -1202,135 +1206,59 @@ binary_sensor:
     address: 0x0
     bitmask: 0x8000
 
-  # Register: 5
-  # Bit: 0
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
+  # Register: 5 -> moved to switch without these marked as reserved_bit and one R/O
+  # Bit: 0  -> not used
+  - platform: template
     name: "Function Setting Reserved BIT 0"
     id: "${devicename}_function_setting_reserved_bit_0"
     icon: mdi:head-question-outline
-    register_type: holding
-    address: 0x5
-    bitmask: 0x1
-  # Bit: 1
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
+    lambda: "return (id(unmasked_value_register_5) & 0x01) == 0x01; // Return status bit1"
+  # Bit: 1  -> not used
+  - platform: template
     name: "Function Setting Reserved BIT 1"
     id: "${devicename}_function_setting_reserved_bit_1"
     icon: mdi:head-question-outline
-    register_type: holding
-    address: 0x5
-    bitmask: 0x2
-  # Bit: 2
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
+    lambda: "return (id(unmasked_value_register_5) & 0x02) == 0x02; // Return status bit1"
+  # Bit: 2  -> not used
+  - platform: template
     name: "Function Setting Reserved BIT 2"
     id: "${devicename}_function_setting_reserved_bit_2"
     icon: mdi:head-question-outline
-    register_type: holding
-    address: 0x5
-    bitmask: 0x4
-  # Bit: 3
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
+    lambda: "return (id(unmasked_value_register_5) & 0x04) == 0x04; // Return status bit2"
+  # Bit: 3 -> not used
+  - platform: template
     name: "Function Setting Reserved BIT 3"
     id: "${devicename}_function_setting_reserved_bit_3"
     icon: mdi:head-question-outline
-    register_type: holding
-    address: 0x5
-    bitmask: 0x8
-  # Bit: 4
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Function Setting Disinfect"
-    id: "${devicename}_function_setting_disinfect"
-    icon: mdi:eye
-    register_type: holding
-    address: 0x5
-    bitmask: 0x10
-  # Bit: 5
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
+    lambda: "return (id(unmasked_value_register_5) & 0x08) == 0x08; // Return status bit3"
+  # Bit: 4 -> Is present in this config as a 'switch'
+  # Bit: 5 -> is R/O but changed to template to avoid multiple modbus requests
+  - platform: template
     name: "Function Setting Holiday Away"
     id: "${devicename}_function_setting_holiday_away"
     icon: mdi:eye
-    register_type: holding
-    address: 0x5
-    bitmask: 0x20
-  # Bit: 6
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Function Setting Silent Mode"
-    id: "${devicename}_function_setting_silent_mode"
-    icon: mdi:eye
-    register_type: holding
-    address: 0x5
-    bitmask: 0x40
-  # Bit: 7
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Function Setting Silent Mode Level"
-    id: "${devicename}_function_setting_silent_mode_level"
-    icon: mdi:eye
-    register_type: holding
-    address: 0x5
-    bitmask: 0x80
-  # Bit: 8
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Function Setting Holiday Home"
-    id: "${devicename}_function_setting_holiday_home"
-    icon: mdi:eye
-    register_type: holding
-    address: 0x5
-    bitmask: 0x100
-  # Bit: 9
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Function Setting Reserved BIT 9"
-    id: "${devicename}_function_setting_reserved_bit_9"
-    icon: mdi:head-question-outline
-    register_type: holding
-    address: 0x5
-    bitmask: 0x200
-  # Bit: 10
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Function Setting ECO Mode"
-    id: "${devicename}_function_setting_eco_mode"
-    icon: mdi:eye
-    register_type: holding
-    address: 0x5
-    bitmask: 0x400
-  # Bit: 11
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Function Setting DHW Pumps Running Constant Temperature Water Recycling"
-    id: "${devicename}_function_setting_dhw_pumps_running_constant_temperature_water_recycling"
-    icon: mdi:eye
-    register_type: holding
-    address: 0x5
-    bitmask: 0x800
+    #disabled_by_default: true
+    lambda: "return (id(unmasked_value_register_5) & 0x20) == 0x20; // Return status bit5"
+  # Bit: 6 -> Is present in this config as a 'switch'
+  # Bit: 7 -> Is present in this config as a 'switch'
+  # Bit: 8 -> Is present in this config as a 'switch'
+  # Bit: 9 -> Is present in this config as a 'switch'
+  # Bit: 10 -> Is present in this config as a 'switch'
+  # Bit: 11 -> Is present in this config as a 'switch'
   # Bit: 12 -> Is present in this config as a 'switch'
   # Bit: 13 -> Is present in this config as a 'switch'
-  # Bit: 14
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
+  # Bit: 14 -> not used
+  - platform: template
     name: "Function Setting Reserved BIT 14"
     id: "${devicename}_function_setting_reserved_bit_14"
     icon: mdi:head-question-outline
-    register_type: holding
-    address: 0x5
-    bitmask: 0x4000
-  # Bit: 15
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
+    lambda: "return (id(unmasked_value_register_5) & 0x4000) == 0x4000; // Return status bit14"
+  # Bit: 15 -> not used
+  - platform: template
     name: "Function Setting Reserved BIT 15"
     id: "${devicename}_function_setting_reserved_bit_15"
     icon: mdi:head-question-outline
-    register_type: holding
-    address: 0x5
-    bitmask: 0x8000
+    lambda: "return (id(unmasked_value_register_5) & 0x8000) == 0x8000; // Return status bit15"
 
   # Register: 128
   # Bit: 0
@@ -2240,26 +2168,271 @@ switch:
             esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
             ${devicename}->queue_command(set_payload_command);
           }
+
+  # Register: 5 -> Bit: 4
+  - platform: template
+    name: "Function Setting Disinfect"
+    id: "${devicename}_function_setting_disinfect"
+    icon: mdi:eye
+    entity_category: config
+    restore_mode: DISABLED
+    optimistic : true
+    lambda: "return (id(unmasked_value_register_5) & 0x10) == 0x10; //return status bit 4"
+    on_turn_on:
+      # - logger.log: "Switch Turned On!"
+      - lambda: |-
+          uint16_t checked_bit = 0x10;                         // Bit to change
+          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
+          new_value &= ~checked_bit;                           // Clear and set
+          new_value += checked_bit;
+          if ((new_value) != id(unmasked_value_register_5)) {
+            // ESP_LOGD("unmasked_value_register_5", "Set option to on f_s_disinfect 0x%x -> 0x%xs", id(unmasked_value_register_5), new_value);
+            id(unmasked_value_register_5) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
+    on_turn_off:
+      # - logger.log: "Switch Turned Off!"    
+      - lambda: |-
+          uint16_t checked_bit = 0x10;                         // Bit to change
+          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
+          new_value &= ~checked_bit;                           // Clear and set
+          if ((new_value) != id(unmasked_value_register_5)) {
+            // ESP_LOGD("unmasked_value_register_5", "Set option to off f_s_disinfect 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
+            id(unmasked_value_register_5) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }  
+  # Register: 5 -> Bit: 5 Holiday -> as Binary Sensor -it is possible to read but not to save
+  # Register: 5 -> Bit: 6
+  - platform: template
+    name: "Function Setting Silent Mode"
+    id: "${devicename}_function_setting_silent_mode"
+    icon: mdi:eye
+    entity_category: config
+    restore_mode: DISABLED
+    optimistic : true
+    lambda: "return (id(unmasked_value_register_5) & 0x40) == 0x40;"
+    on_turn_on:
+      - lambda: |-
+          uint16_t checked_bit = 0x40;
+          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
+          new_value &= ~checked_bit;         // Clear and set
+          new_value += checked_bit;
+          if ((new_value) != id(unmasked_value_register_5)) {
+            // ESP_LOGD("unmasked_value_register_5", "Set option to on f_s_silent_mode 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
+            id(unmasked_value_register_5) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x5, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
+    on_turn_off:
+      - lambda: |-
+          uint16_t checked_bit = 0x40;
+          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
+          new_value &= ~checked_bit;         // Clear and set
+          if ((new_value) != id(unmasked_value_register_5)) {
+            // ESP_LOGD("unmasked_value_register_5", "Set option to off f_s_silent_mode 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
+            id(unmasked_value_register_5) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x5, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }  
+  # Register: 5 -> Bit: 7
+  - platform: template
+    name: "Function Setting Silent Mode Level" #silent or very silent
+    id: "${devicename}_function_setting_silent_mode_level"
+    icon: mdi:eye
+    #address: 5
+    #bitmask: 0x80
+    entity_category: config
+    restore_mode: DISABLED
+    optimistic : true
+    lambda: "return (id(unmasked_value_register_5) & 0x80) == 0x80;"
+    on_turn_on:
+      - lambda: |-
+          uint16_t checked_bit = 0x80;
+          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
+          new_value &= ~checked_bit;         // Clear and set
+          new_value += checked_bit;
+          if ((new_value) != id(unmasked_value_register_5)) {
+            // ESP_LOGD("unmasked_value_register_5", "Set option to on f_s_silent_mode_level 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
+            id(unmasked_value_register_5) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
+    on_turn_off:
+      - lambda: |-
+          uint16_t checked_bit = 0x80;
+          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
+          new_value &= ~checked_bit;         // Clear and set
+          if ((new_value) != id(unmasked_value_register_5)) {
+            // ESP_LOGD("unmasked_value_register_5", "Set option to off f_s_silent_mode_level 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
+            id(unmasked_value_register_5) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
+  # Register: 5 -> Bit: 8
+  - platform: template
+    name: "Function Setting Holiday Home"
+    id: "${devicename}_function_setting_holiday_home"
+    disabled_by_default: true
+    icon: mdi:eye
+    entity_category: config
+    restore_mode: DISABLED
+    optimistic : true
+    lambda: "return (id(unmasked_value_register_5) & 0x100) == 0x100;"
+    on_turn_on:
+      - lambda: |-
+          uint16_t checked_bit = 0x100;
+          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
+          new_value &= ~checked_bit;         // Clear and set
+          new_value += checked_bit;
+          if ((new_value) != id(unmasked_value_register_5)) {
+            // ESP_LOGD("unmasked_value_register_5", "Set option to on f_s_holiday_home 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
+            id(unmasked_value_register_5) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
+    on_turn_off:
+      - lambda: |-
+          uint16_t checked_bit = 0x100;
+          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
+          new_value &= ~checked_bit;         // Clear and set
+          if ((new_value) != id(unmasked_value_register_5)) {
+            // ESP_LOGD("unmasked_value_register_5", "Set option to off f_s_holiday_home 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
+            id(unmasked_value_register_5) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }  
+  # Register: 5 -> Bit 9 at binary sensor not used
+  # Register: 5 -> Bit: 10
+  - platform: template
+    name: "Function Setting ECO Mode"
+    id: "${devicename}_function_setting_eco_mode"
+    disabled_by_default: true
+    icon: mdi:eye
+    entity_category: config
+    restore_mode: DISABLED
+    optimistic : true
+    lambda: "return (id(unmasked_value_register_5) & 0x400) == 0x400;"
+    on_turn_on:
+      - lambda: |-
+          uint16_t checked_bit = 0x400;
+          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
+          new_value &= ~checked_bit;         // Clear and set
+          new_value += checked_bit;
+          if ((new_value) != id(unmasked_value_register_5)) {
+            // ESP_LOGD("unmasked_value_register_5", "Set option to on f_s_eco_mode 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
+            id(unmasked_value_register_5) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
+    on_turn_off:
+      - lambda: |-
+          uint16_t checked_bit = 0x400;
+          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
+          new_value &= ~checked_bit;         //Clear and set
+          if ((new_value) != id(unmasked_value_register_5)) {
+            // ESP_LOGD("unmasked_value_register_5", "Set option to off f_s_eco_mode 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
+            id(unmasked_value_register_5) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
+  # Register: 5 -> Bit: 11
+  - platform: template
+    name: "Function Setting DHW Pumps Running Constant Temperature Water Recycling"
+    id: "${devicename}_function_setting_dhw_pumps_running_constant_temperature_water_recycling"
+    icon: mdi:eye
+    entity_category: config
+    restore_mode: DISABLED
+    optimistic : true
+    lambda: "return (id(unmasked_value_register_5) & 0x800) == 0x800;"
+    on_turn_on:
+      - lambda: |-
+          uint16_t checked_bit = 0x800;
+          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
+          new_value &= ~checked_bit;         // Clear and set
+          new_value += checked_bit;
+          if ((new_value) != id(unmasked_value_register_5)) {
+            // ESP_LOGD("unmasked_value_register_5", "Set option to on f_s_dhw_pumps_running_constant_temperature_water_recycling 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
+            id(unmasked_value_register_5) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
+    on_turn_off:
+      - lambda: |-
+          uint16_t checked_bit = 0x800;
+          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
+          new_value &= ~checked_bit;         // Clear and set
+          if ((new_value) != id(unmasked_value_register_5)) {
+            // ESP_LOGD("unmasked_value_register_5", "Set option to off f_s_dhw_pumps_running_constant_temperature_water_recycling 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
+            id(unmasked_value_register_5) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }          
   # Register: 5 -> Bit 12
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
+  - platform: template
     name: "Weather Compensation Zone 1"
     id: "${devicename}_weather_compensation_zone_1"
     icon: mdi:eye
-    register_type: holding
     entity_category: config
-    address: 0x5
-    bitmask: 0x1000
+    restore_mode: DISABLED
+    optimistic : true
+    lambda: "return (id(unmasked_value_register_5) & 0x1000) == 0x1000;"
+    on_turn_on:
+      - lambda: |-
+          uint16_t checked_bit = 0x1000;
+          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
+          new_value &= ~checked_bit;         // Clear and set
+          new_value += checked_bit;
+          if ((new_value) != id(unmasked_value_register_5)) {
+            // ESP_LOGD("unmasked_value_register_5", "Set option to on weather_compensation_zone_1 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
+            id(unmasked_value_register_5) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
+    on_turn_off:
+      - lambda: |-
+          uint16_t checked_bit = 0x1000;
+          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
+          new_value &= ~checked_bit;         // Clear and set
+          if ((new_value) != id(unmasked_value_register_5)) {
+            // ESP_LOGD("unmasked_value_register_5", "Set option to off weather_compensation_zone_1 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
+            id(unmasked_value_register_5) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
   # Register: 5 -> Bit 13
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
+  - platform: template
     name: "Weather Compensation Zone 2"
     id: "${devicename}_weather_compensation_zone_2"
     icon: mdi:eye
-    register_type: holding
     entity_category: config
-    address: 0x5
-    bitmask: 0x2000
+    restore_mode: DISABLED
+    optimistic : true
+    lambda: "return (id(unmasked_value_register_5) & 0x2000) == 0x2000;"
+    on_turn_on:
+      - lambda: |-
+          uint16_t checked_bit = 0x2000;
+          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
+          new_value &= ~checked_bit;         // Clear and set
+          new_value += checked_bit;
+          if ((new_value) != id(unmasked_value_register_5)) {
+            // ESP_LOGD("unmasked_value_register_5", "Set option to on weather_compensation_zone_2 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
+            id(unmasked_value_register_5) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
+    on_turn_off:
+      - lambda: |-
+          uint16_t checked_bit = 0x2000;
+          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
+          new_value &= ~checked_bit;         //Clear and set
+          if ((new_value) != id(unmasked_value_register_5)) {
+            // ESP_LOGD("unmasked_value_register_5", "Set option to off weather_compensation_zone_2 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
+            id(unmasked_value_register_5) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
 
   # Register: 7
   - platform: modbus_controller
@@ -2382,6 +2555,21 @@ number:
     min_value: 20
     max_value: 60
     mode: slider
+
+  # Register: 5 -> Config is present as select, but now we need get value from heatpump and save it as global var
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Register 5 switches"
+    id: "${devicename}_register_5_switches"
+    internal: true
+    register_type: holding
+    address: 0x5
+    value_type: U_WORD
+    icon: mdi:eye
+    lambda: |-
+      // Update the global var unmasked_value_register_5
+      id(unmasked_value_register_5) = x;
+      return x;
 
   # Register: 6 (Zone 1, Low)
   - platform: modbus_controller

--- a/heatpump.yaml
+++ b/heatpump.yaml
@@ -7,10 +7,6 @@ globals:
     type: uint16_t
     restore_value: true
     # initial_value: '0'
-  - id: unmasked_value_register_5
-    type: uint16_t
-    restore_value: true
-    # initial_value: '0'    
   - id: unmasked_value_water_temperature_t1s
     type: uint16_t
     restore_value: no
@@ -1206,59 +1202,135 @@ binary_sensor:
     address: 0x0
     bitmask: 0x8000
 
-  # Register: 5 -> moved to switch without these marked as reserved_bit and one R/O
-  # Bit: 0  -> not used
-  - platform: template
+  # Register: 5
+  # Bit: 0
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
     name: "Function Setting Reserved BIT 0"
     id: "${devicename}_function_setting_reserved_bit_0"
     icon: mdi:head-question-outline
-    lambda: "return (id(unmasked_value_register_5) & 0x01) == 0x01; // Return status bit1"
-  # Bit: 1  -> not used
-  - platform: template
+    register_type: holding
+    address: 0x5
+    bitmask: 0x1
+  # Bit: 1
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
     name: "Function Setting Reserved BIT 1"
     id: "${devicename}_function_setting_reserved_bit_1"
     icon: mdi:head-question-outline
-    lambda: "return (id(unmasked_value_register_5) & 0x02) == 0x02; // Return status bit1"
-  # Bit: 2  -> not used
-  - platform: template
+    register_type: holding
+    address: 0x5
+    bitmask: 0x2
+  # Bit: 2
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
     name: "Function Setting Reserved BIT 2"
     id: "${devicename}_function_setting_reserved_bit_2"
     icon: mdi:head-question-outline
-    lambda: "return (id(unmasked_value_register_5) & 0x04) == 0x04; // Return status bit2"
-  # Bit: 3 -> not used
-  - platform: template
+    register_type: holding
+    address: 0x5
+    bitmask: 0x4
+  # Bit: 3
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
     name: "Function Setting Reserved BIT 3"
     id: "${devicename}_function_setting_reserved_bit_3"
     icon: mdi:head-question-outline
-    lambda: "return (id(unmasked_value_register_5) & 0x08) == 0x08; // Return status bit3"
-  # Bit: 4 -> Is present in this config as a 'switch'
-  # Bit: 5 -> is R/O but changed to template to avoid multiple modbus requests
-  - platform: template
+    register_type: holding
+    address: 0x5
+    bitmask: 0x8
+  # Bit: 4
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Function Setting Disinfect"
+    id: "${devicename}_function_setting_disinfect"
+    icon: mdi:eye
+    register_type: holding
+    address: 0x5
+    bitmask: 0x10
+  # Bit: 5
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
     name: "Function Setting Holiday Away"
     id: "${devicename}_function_setting_holiday_away"
     icon: mdi:eye
-    #disabled_by_default: true
-    lambda: "return (id(unmasked_value_register_5) & 0x20) == 0x20; // Return status bit5"
-  # Bit: 6 -> Is present in this config as a 'switch'
-  # Bit: 7 -> Is present in this config as a 'switch'
-  # Bit: 8 -> Is present in this config as a 'switch'
-  # Bit: 9 -> Is present in this config as a 'switch'
-  # Bit: 10 -> Is present in this config as a 'switch'
-  # Bit: 11 -> Is present in this config as a 'switch'
+    register_type: holding
+    address: 0x5
+    bitmask: 0x20
+  # Bit: 6
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Function Setting Silent Mode"
+    id: "${devicename}_function_setting_silent_mode"
+    icon: mdi:eye
+    register_type: holding
+    address: 0x5
+    bitmask: 0x40
+  # Bit: 7
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Function Setting Silent Mode Level"
+    id: "${devicename}_function_setting_silent_mode_level"
+    icon: mdi:eye
+    register_type: holding
+    address: 0x5
+    bitmask: 0x80
+  # Bit: 8
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Function Setting Holiday Home"
+    id: "${devicename}_function_setting_holiday_home"
+    icon: mdi:eye
+    register_type: holding
+    address: 0x5
+    bitmask: 0x100
+  # Bit: 9
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Function Setting Reserved BIT 9"
+    id: "${devicename}_function_setting_reserved_bit_9"
+    icon: mdi:head-question-outline
+    register_type: holding
+    address: 0x5
+    bitmask: 0x200
+  # Bit: 10
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Function Setting ECO Mode"
+    id: "${devicename}_function_setting_eco_mode"
+    icon: mdi:eye
+    register_type: holding
+    address: 0x5
+    bitmask: 0x400
+  # Bit: 11
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Function Setting DHW Pumps Running Constant Temperature Water Recycling"
+    id: "${devicename}_function_setting_dhw_pumps_running_constant_temperature_water_recycling"
+    icon: mdi:eye
+    register_type: holding
+    address: 0x5
+    bitmask: 0x800
   # Bit: 12 -> Is present in this config as a 'switch'
   # Bit: 13 -> Is present in this config as a 'switch'
-  # Bit: 14 -> not used
-  - platform: template
+  # Bit: 14
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
     name: "Function Setting Reserved BIT 14"
     id: "${devicename}_function_setting_reserved_bit_14"
     icon: mdi:head-question-outline
-    lambda: "return (id(unmasked_value_register_5) & 0x4000) == 0x4000; // Return status bit14"
-  # Bit: 15 -> not used
-  - platform: template
+    register_type: holding
+    address: 0x5
+    bitmask: 0x4000
+  # Bit: 15
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
     name: "Function Setting Reserved BIT 15"
     id: "${devicename}_function_setting_reserved_bit_15"
     icon: mdi:head-question-outline
-    lambda: "return (id(unmasked_value_register_5) & 0x8000) == 0x8000; // Return status bit15"
+    register_type: holding
+    address: 0x5
+    bitmask: 0x8000
 
   # Register: 128
   # Bit: 0
@@ -2032,7 +2104,7 @@ switch:
       - lambda: |-
           uint16_t checked_bit = 0x1;
           uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
-          new_value &= ~checked_bit;         // Clear and set
+          new_value &= ~checked_bit;                           // Clear and set
           new_value += checked_bit;
           if ((new_value) != id(unmasked_value_register_0)) {
             // ESP_LOGD("unmasked_value_register_0", "Set option to on power_air_conditioner_zone_1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
@@ -2045,7 +2117,7 @@ switch:
       - lambda: |-
           uint16_t checked_bit = 0x1;
           uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
-          new_value &= ~checked_bit;         // Clear and set
+          new_value &= ~checked_bit;                           // Clear and set
           if ((new_value) != id(unmasked_value_register_0)) {
             // ESP_LOGD("unmasked_value_register_0", "Set option to off power_air_conditioner_zone_1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
             id(unmasked_value_register_0) = new_value;
@@ -2085,7 +2157,7 @@ switch:
       - lambda: |-
           uint16_t checked_bit = 0x2;
           uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
-          new_value &= ~checked_bit;         // Clear and set
+          new_value &= ~checked_bit;                           // Clear and set
           if ((new_value) != id(unmasked_value_register_0)) {
             // ESP_LOGD("unmasked_value_register_0", "Set option to off power_heat_cool_control_zone1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
             id(unmasked_value_register_0) = new_value;
@@ -2120,7 +2192,7 @@ switch:
       - lambda: |-
           uint16_t checked_bit = 0x4;
           uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
-          new_value &= ~checked_bit;         // Clear and set
+          new_value &= ~checked_bit;                           // Clear and set
           
           if ((new_value) != id(unmasked_value_register_0)) {
             // ESP_LOGD("unmasked_value_register_0", "Set option to off power_dhw_t5s 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
@@ -2147,7 +2219,7 @@ switch:
       - lambda: |-
           uint16_t checked_bit = 0x8;
           uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
-          new_value &= ~checked_bit;         // Clear and set
+          new_value &= ~checked_bit;                           // Clear and set
           new_value += checked_bit;
           if ((new_value) != id(unmasked_value_register_0)) {
             // ESP_LOGD("unmasked_value_register_0", "Set option to on power_air_conditioner_zone_2 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
@@ -2160,7 +2232,7 @@ switch:
       - lambda: |-
           uint16_t checked_bit = 0x8;
           uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
-          new_value &= ~checked_bit;         // Clear and set
+          new_value &= ~checked_bit;                           // Clear and set
           
           if ((new_value) != id(unmasked_value_register_0)) {
             // ESP_LOGD("unmasked_value_register_0", "Set option to off power_air_conditioner_zone_2 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
@@ -2168,271 +2240,26 @@ switch:
             esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
             ${devicename}->queue_command(set_payload_command);
           }
-
-  # Register: 5 -> Bit: 4
-  - platform: template
-    name: "Function Setting Disinfect"
-    id: "${devicename}_function_setting_disinfect"
-    icon: mdi:eye
-    entity_category: config
-    restore_mode: DISABLED
-    optimistic : true
-    lambda: "return (id(unmasked_value_register_5) & 0x10) == 0x10; //return status bit 4"
-    on_turn_on:
-      # - logger.log: "Switch Turned On!"
-      - lambda: |-
-          uint16_t checked_bit = 0x10;                         // Bit to change
-          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
-          new_value &= ~checked_bit;                           // Clear and set
-          new_value += checked_bit;
-          if ((new_value) != id(unmasked_value_register_5)) {
-            // ESP_LOGD("unmasked_value_register_5", "Set option to on f_s_disinfect 0x%x -> 0x%xs", id(unmasked_value_register_5), new_value);
-            id(unmasked_value_register_5) = new_value;
-            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
-            ${devicename}->queue_command(set_payload_command);
-          }
-    on_turn_off:
-      # - logger.log: "Switch Turned Off!"    
-      - lambda: |-
-          uint16_t checked_bit = 0x10;                         // Bit to change
-          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
-          new_value &= ~checked_bit;                           // Clear and set
-          if ((new_value) != id(unmasked_value_register_5)) {
-            // ESP_LOGD("unmasked_value_register_5", "Set option to off f_s_disinfect 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
-            id(unmasked_value_register_5) = new_value;
-            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
-            ${devicename}->queue_command(set_payload_command);
-          }  
-  # Register: 5 -> Bit: 5 Holiday -> as Binary Sensor -it is possible to read but not to save
-  # Register: 5 -> Bit: 6
-  - platform: template
-    name: "Function Setting Silent Mode"
-    id: "${devicename}_function_setting_silent_mode"
-    icon: mdi:eye
-    entity_category: config
-    restore_mode: DISABLED
-    optimistic : true
-    lambda: "return (id(unmasked_value_register_5) & 0x40) == 0x40;"
-    on_turn_on:
-      - lambda: |-
-          uint16_t checked_bit = 0x40;
-          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
-          new_value &= ~checked_bit;         // Clear and set
-          new_value += checked_bit;
-          if ((new_value) != id(unmasked_value_register_5)) {
-            // ESP_LOGD("unmasked_value_register_5", "Set option to on f_s_silent_mode 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
-            id(unmasked_value_register_5) = new_value;
-            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x5, new_value);
-            ${devicename}->queue_command(set_payload_command);
-          }
-    on_turn_off:
-      - lambda: |-
-          uint16_t checked_bit = 0x40;
-          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
-          new_value &= ~checked_bit;         // Clear and set
-          if ((new_value) != id(unmasked_value_register_5)) {
-            // ESP_LOGD("unmasked_value_register_5", "Set option to off f_s_silent_mode 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
-            id(unmasked_value_register_5) = new_value;
-            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x5, new_value);
-            ${devicename}->queue_command(set_payload_command);
-          }  
-  # Register: 5 -> Bit: 7
-  - platform: template
-    name: "Function Setting Silent Mode Level" #silent or very silent
-    id: "${devicename}_function_setting_silent_mode_level"
-    icon: mdi:eye
-    #address: 5
-    #bitmask: 0x80
-    entity_category: config
-    restore_mode: DISABLED
-    optimistic : true
-    lambda: "return (id(unmasked_value_register_5) & 0x80) == 0x80;"
-    on_turn_on:
-      - lambda: |-
-          uint16_t checked_bit = 0x80;
-          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
-          new_value &= ~checked_bit;         // Clear and set
-          new_value += checked_bit;
-          if ((new_value) != id(unmasked_value_register_5)) {
-            // ESP_LOGD("unmasked_value_register_5", "Set option to on f_s_silent_mode_level 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
-            id(unmasked_value_register_5) = new_value;
-            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
-            ${devicename}->queue_command(set_payload_command);
-          }
-    on_turn_off:
-      - lambda: |-
-          uint16_t checked_bit = 0x80;
-          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
-          new_value &= ~checked_bit;         // Clear and set
-          if ((new_value) != id(unmasked_value_register_5)) {
-            // ESP_LOGD("unmasked_value_register_5", "Set option to off f_s_silent_mode_level 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
-            id(unmasked_value_register_5) = new_value;
-            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
-            ${devicename}->queue_command(set_payload_command);
-          }
-  # Register: 5 -> Bit: 8
-  - platform: template
-    name: "Function Setting Holiday Home"
-    id: "${devicename}_function_setting_holiday_home"
-    disabled_by_default: true
-    icon: mdi:eye
-    entity_category: config
-    restore_mode: DISABLED
-    optimistic : true
-    lambda: "return (id(unmasked_value_register_5) & 0x100) == 0x100;"
-    on_turn_on:
-      - lambda: |-
-          uint16_t checked_bit = 0x100;
-          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
-          new_value &= ~checked_bit;         // Clear and set
-          new_value += checked_bit;
-          if ((new_value) != id(unmasked_value_register_5)) {
-            // ESP_LOGD("unmasked_value_register_5", "Set option to on f_s_holiday_home 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
-            id(unmasked_value_register_5) = new_value;
-            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
-            ${devicename}->queue_command(set_payload_command);
-          }
-    on_turn_off:
-      - lambda: |-
-          uint16_t checked_bit = 0x100;
-          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
-          new_value &= ~checked_bit;         // Clear and set
-          if ((new_value) != id(unmasked_value_register_5)) {
-            // ESP_LOGD("unmasked_value_register_5", "Set option to off f_s_holiday_home 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
-            id(unmasked_value_register_5) = new_value;
-            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
-            ${devicename}->queue_command(set_payload_command);
-          }  
-  # Register: 5 -> Bit 9 at binary sensor not used
-  # Register: 5 -> Bit: 10
-  - platform: template
-    name: "Function Setting ECO Mode"
-    id: "${devicename}_function_setting_eco_mode"
-    disabled_by_default: true
-    icon: mdi:eye
-    entity_category: config
-    restore_mode: DISABLED
-    optimistic : true
-    lambda: "return (id(unmasked_value_register_5) & 0x400) == 0x400;"
-    on_turn_on:
-      - lambda: |-
-          uint16_t checked_bit = 0x400;
-          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
-          new_value &= ~checked_bit;         // Clear and set
-          new_value += checked_bit;
-          if ((new_value) != id(unmasked_value_register_5)) {
-            // ESP_LOGD("unmasked_value_register_5", "Set option to on f_s_eco_mode 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
-            id(unmasked_value_register_5) = new_value;
-            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
-            ${devicename}->queue_command(set_payload_command);
-          }
-    on_turn_off:
-      - lambda: |-
-          uint16_t checked_bit = 0x400;
-          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
-          new_value &= ~checked_bit;         //Clear and set
-          if ((new_value) != id(unmasked_value_register_5)) {
-            // ESP_LOGD("unmasked_value_register_5", "Set option to off f_s_eco_mode 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
-            id(unmasked_value_register_5) = new_value;
-            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
-            ${devicename}->queue_command(set_payload_command);
-          }
-  # Register: 5 -> Bit: 11
-  - platform: template
-    name: "Function Setting DHW Pumps Running Constant Temperature Water Recycling"
-    id: "${devicename}_function_setting_dhw_pumps_running_constant_temperature_water_recycling"
-    icon: mdi:eye
-    entity_category: config
-    restore_mode: DISABLED
-    optimistic : true
-    lambda: "return (id(unmasked_value_register_5) & 0x800) == 0x800;"
-    on_turn_on:
-      - lambda: |-
-          uint16_t checked_bit = 0x800;
-          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
-          new_value &= ~checked_bit;         // Clear and set
-          new_value += checked_bit;
-          if ((new_value) != id(unmasked_value_register_5)) {
-            // ESP_LOGD("unmasked_value_register_5", "Set option to on f_s_dhw_pumps_running_constant_temperature_water_recycling 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
-            id(unmasked_value_register_5) = new_value;
-            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
-            ${devicename}->queue_command(set_payload_command);
-          }
-    on_turn_off:
-      - lambda: |-
-          uint16_t checked_bit = 0x800;
-          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
-          new_value &= ~checked_bit;         // Clear and set
-          if ((new_value) != id(unmasked_value_register_5)) {
-            // ESP_LOGD("unmasked_value_register_5", "Set option to off f_s_dhw_pumps_running_constant_temperature_water_recycling 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
-            id(unmasked_value_register_5) = new_value;
-            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
-            ${devicename}->queue_command(set_payload_command);
-          }          
   # Register: 5 -> Bit 12
-  - platform: template
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
     name: "Weather Compensation Zone 1"
     id: "${devicename}_weather_compensation_zone_1"
     icon: mdi:eye
+    register_type: holding
     entity_category: config
-    restore_mode: DISABLED
-    optimistic : true
-    lambda: "return (id(unmasked_value_register_5) & 0x1000) == 0x1000;"
-    on_turn_on:
-      - lambda: |-
-          uint16_t checked_bit = 0x1000;
-          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
-          new_value &= ~checked_bit;         // Clear and set
-          new_value += checked_bit;
-          if ((new_value) != id(unmasked_value_register_5)) {
-            // ESP_LOGD("unmasked_value_register_5", "Set option to on weather_compensation_zone_1 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
-            id(unmasked_value_register_5) = new_value;
-            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
-            ${devicename}->queue_command(set_payload_command);
-          }
-    on_turn_off:
-      - lambda: |-
-          uint16_t checked_bit = 0x1000;
-          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
-          new_value &= ~checked_bit;         // Clear and set
-          if ((new_value) != id(unmasked_value_register_5)) {
-            // ESP_LOGD("unmasked_value_register_5", "Set option to off weather_compensation_zone_1 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
-            id(unmasked_value_register_5) = new_value;
-            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
-            ${devicename}->queue_command(set_payload_command);
-          }
+    address: 0x5
+    bitmask: 0x1000
   # Register: 5 -> Bit 13
-  - platform: template
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
     name: "Weather Compensation Zone 2"
     id: "${devicename}_weather_compensation_zone_2"
     icon: mdi:eye
+    register_type: holding
     entity_category: config
-    restore_mode: DISABLED
-    optimistic : true
-    lambda: "return (id(unmasked_value_register_5) & 0x2000) == 0x2000;"
-    on_turn_on:
-      - lambda: |-
-          uint16_t checked_bit = 0x2000;
-          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
-          new_value &= ~checked_bit;         // Clear and set
-          new_value += checked_bit;
-          if ((new_value) != id(unmasked_value_register_5)) {
-            // ESP_LOGD("unmasked_value_register_5", "Set option to on weather_compensation_zone_2 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
-            id(unmasked_value_register_5) = new_value;
-            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
-            ${devicename}->queue_command(set_payload_command);
-          }
-    on_turn_off:
-      - lambda: |-
-          uint16_t checked_bit = 0x2000;
-          uint16_t new_value = id(unmasked_value_register_5);  // The original unmasked value
-          new_value &= ~checked_bit;         //Clear and set
-          if ((new_value) != id(unmasked_value_register_5)) {
-            // ESP_LOGD("unmasked_value_register_5", "Set option to off weather_compensation_zone_2 0x%x -> 0x%x", id(unmasked_value_register_5), new_value);
-            id(unmasked_value_register_5) = new_value;
-            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 5, new_value);
-            ${devicename}->queue_command(set_payload_command);
-          }
+    address: 0x5
+    bitmask: 0x2000
 
   # Register: 7
   - platform: modbus_controller
@@ -2555,21 +2382,6 @@ number:
     min_value: 20
     max_value: 60
     mode: slider
-
-  # Register: 5 -> Config is present as select, but now we need get value from heatpump and save it as global var
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Register 5 switches"
-    id: "${devicename}_register_5_switches"
-    internal: true
-    register_type: holding
-    address: 0x5
-    value_type: U_WORD
-    icon: mdi:eye
-    lambda: |-
-      // Update the global var unmasked_value_register_5
-      id(unmasked_value_register_5) = x;
-      return x;
 
   # Register: 6 (Zone 1, Low)
   - platform: modbus_controller

--- a/heatpump.yaml
+++ b/heatpump.yaml
@@ -1088,119 +1088,119 @@ sensor:
       return t1s_dhw;
 
 binary_sensor:
-  # Register: 0 ->Is read as sensor from modbus to be fully switch functiuoning
+  # Register: 0 ->Is read as sensor from modbus to be fully switch functioning
   # Bit: 0 -> Is present in this config as a 'switch'
   # Bit: 1 -> Is present in this config as a 'switch'
   # Bit: 2 -> Is present in this config as a 'switch'
   # Bit: 3 -> Is present in this config as a 'switch'
   # Bit: 4 -> not used
-  # - platform: modbus_controller
-  #   modbus_controller_id: "${devicename}"
-  #   name: "Power Reserved BIT 4"
-  #   id: "${devicename}_power_reserved_bit_4"
-  #   icon: mdi:head-question-outline
-  #   register_type: holding
-  #   address: 0x0
-  #   bitmask: 0x10
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Power Reserved BIT 4"
+    id: "${devicename}_power_reserved_bit_4"
+    icon: mdi:head-question-outline
+    register_type: holding
+    address: 0x0
+    bitmask: 0x10
   # Bit: 5 -> not used
-  # - platform: modbus_controller
-  #   modbus_controller_id: "${devicename}"
-  #   name: "Power Reserved BIT 5"
-  #   id: "${devicename}_power_reserved_bit_5"
-  #   icon: mdi:head-question-outline
-  #   register_type: holding
-  #   address: 0x0
-  #   bitmask: 0x20
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Power Reserved BIT 5"
+    id: "${devicename}_power_reserved_bit_5"
+    icon: mdi:head-question-outline
+    register_type: holding
+    address: 0x0
+    bitmask: 0x20
   # Bit: 6 -> not used
-  # - platform: modbus_controller
-  #   modbus_controller_id: "${devicename}"
-  #   name: "Power Reserved BIT 6"
-  #   id: "${devicename}_power_reserved_bit_6"
-  #   icon: mdi:head-question-outline
-  #   register_type: holding
-  #   address: 0x0
-  #   bitmask: 0x40
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Power Reserved BIT 6"
+    id: "${devicename}_power_reserved_bit_6"
+    icon: mdi:head-question-outline
+    register_type: holding
+    address: 0x0
+    bitmask: 0x40
   # Bit: 7 -> not used
-  # - platform: modbus_controller
-  #   modbus_controller_id: "${devicename}"
-  #   name: "Power Reserved BIT 7"
-  #   id: "${devicename}_power_reserved_bit_7"
-  #   icon: mdi:head-question-outline
-  #   register_type: holding
-  #   address: 0x0
-  #   bitmask: 0x80
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Power Reserved BIT 7"
+    id: "${devicename}_power_reserved_bit_7"
+    icon: mdi:head-question-outline
+    register_type: holding
+    address: 0x0
+    bitmask: 0x80
   # Bit: 8 -> not used
-  # - platform: modbus_controller
-  #   modbus_controller_id: "${devicename}"
-  #   name: "Power Reserved BIT 8"
-  #   id: "${devicename}_power_reserved_bit_8"
-  #   icon: mdi:head-question-outline
-  #   register_type: holding
-  #   address: 0x0
-  #   bitmask: 0x100
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Power Reserved BIT 8"
+    id: "${devicename}_power_reserved_bit_8"
+    icon: mdi:head-question-outline
+    register_type: holding
+    address: 0x0
+    bitmask: 0x100
   # Bit: 9 -> not used
-  # - platform: modbus_controller
-  #   modbus_controller_id: "${devicename}"
-  #   name: "Power Reserved BIT 9"
-  #   id: "${devicename}_power_reserved_bit_9"
-  #   icon: mdi:head-question-outline
-  #   register_type: holding
-  #   address: 0x0
-  #   bitmask: 0x200
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Power Reserved BIT 9"
+    id: "${devicename}_power_reserved_bit_9"
+    icon: mdi:head-question-outline
+    register_type: holding
+    address: 0x0
+    bitmask: 0x200
   # Bit: 10 -> not used
-  # - platform: modbus_controller
-  #   modbus_controller_id: "${devicename}"
-  #   name: "Power Reserved BIT 10"
-  #   id: "${devicename}_power_reserved_bit_10"
-  #   icon: mdi:head-question-outline
-  #   register_type: holding
-  #   address: 0x0
-  #   bitmask: 0x400
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Power Reserved BIT 10"
+    id: "${devicename}_power_reserved_bit_10"
+    icon: mdi:head-question-outline
+    register_type: holding
+    address: 0x0
+    bitmask: 0x400
   # Bit: 11 -> not used
-  # - platform: modbus_controller
-  #   modbus_controller_id: "${devicename}"
-  #   name: "Power Reserved BIT 11"
-  #   id: "${devicename}_power_reserved_bit_11"
-  #   icon: mdi:head-question-outline
-  #   register_type: holding
-  #   address: 0x0
-  #   bitmask: 0x800
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Power Reserved BIT 11"
+    id: "${devicename}_power_reserved_bit_11"
+    icon: mdi:head-question-outline
+    register_type: holding
+    address: 0x0
+    bitmask: 0x800
   # Bit: 12 -> not used
-  # - platform: modbus_controller
-  #   modbus_controller_id: "${devicename}"
-  #   name: "Power Reserved BIT 12"
-  #   id: "${devicename}_power_reserved_bit_12"
-  #   icon: mdi:head-question-outline
-  #   register_type: holding
-  #   address: 0x0
-  #   bitmask: 0x1000
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Power Reserved BIT 12"
+    id: "${devicename}_power_reserved_bit_12"
+    icon: mdi:head-question-outline
+    register_type: holding
+    address: 0x0
+    bitmask: 0x1000
   # Bit: 13 -> not used
-  # - platform: modbus_controller
-  #   modbus_controller_id: "${devicename}"
-  #   name: "Power Reserved BIT 13"
-  #   id: "${devicename}_power_reserved_bit_13"
-  #   icon: mdi:head-question-outline
-  #   register_type: holding
-  #   address: 0x0
-  #   bitmask: 0x2000
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Power Reserved BIT 13"
+    id: "${devicename}_power_reserved_bit_13"
+    icon: mdi:head-question-outline
+    register_type: holding
+    address: 0x0
+    bitmask: 0x2000
   # Bit: 14 -> not used
-  # - platform: modbus_controller
-  #   modbus_controller_id: "${devicename}"
-  #   name: "Power Reserved BIT 14"
-  #   id: "${devicename}_power_reserved_bit_14"
-  #   icon: mdi:head-question-outline
-  #   register_type: holding
-  #   address: 0x0
-  #   bitmask: 0x4000
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Power Reserved BIT 14"
+    id: "${devicename}_power_reserved_bit_14"
+    icon: mdi:head-question-outline
+    register_type: holding
+    address: 0x0
+    bitmask: 0x4000
   # Bit: 15 -> not used
-  # - platform: modbus_controller
-  #   modbus_controller_id: "${devicename}"
-  #   name: "Power Reserved BIT 15"
-  #   id: "${devicename}_power_reserved_bit_15"
-  #   icon: mdi:head-question-outline
-  #   register_type: holding
-  #   address: 0x0
-  #   bitmask: 0x8000
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Power Reserved BIT 15"
+    id: "${devicename}_power_reserved_bit_15"
+    icon: mdi:head-question-outline
+    register_type: holding
+    address: 0x0
+    bitmask: 0x8000
 
   # Register: 5
   # Bit: 0
@@ -2092,7 +2092,7 @@ switch:
   # When Room Temperature Control is enabled, the temperature sensor in the remote controller
   # will be used to define when the heatpump should be turned (powered) on or off
   - platform: template
-    name: "Room Temperature Control"                  #"Power Climate Control -uses FanCoilUnit as emission type"
+    name: "Room Temperature Control"
     id: "${devicename}_room_temperature_control"
     icon: mdi:eye
     entity_category: config
@@ -2100,26 +2100,26 @@ switch:
     optimistic : true
     lambda: "return (id(unmasked_value_register_0) & 0x1) == 0x1;"
     on_turn_on:
-      #- logger.log: "Switch Turned On!"
+      # - logger.log: "Switch Turned On!"
       - lambda: |-
           uint16_t checked_bit = 0x1;
           uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
-          new_value &= ~checked_bit;         //Clear and set
+          new_value &= ~checked_bit;         // Clear and set
           new_value += checked_bit;
           if ((new_value) != id(unmasked_value_register_0)) {
-            ESP_LOGI("unmasked_value_register_0", "Set option to on power_air_conditioner_zone_1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            # ESP_LOGD("unmasked_value_register_0", "Set option to on power_air_conditioner_zone_1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
             id(unmasked_value_register_0) = new_value;
             esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
             ${devicename}->queue_command(set_payload_command);
           }
     on_turn_off:
-      #- logger.log: "Switch Turned Off!"    
+      # - logger.log: "Switch Turned Off!"    
       - lambda: |-
           uint16_t checked_bit = 0x1;
           uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
-          new_value &= ~checked_bit;         //Clear and set
+          new_value &= ~checked_bit;         // Clear and set
           if ((new_value) != id(unmasked_value_register_0)) {
-            ESP_LOGI("unmasked_value_register_0", "Set option to off power_air_conditioner_zone_1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            # ESP_LOGD("unmasked_value_register_0", "Set option to off power_air_conditioner_zone_1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
             id(unmasked_value_register_0) = new_value;
             esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
             ${devicename}->queue_command(set_payload_command);
@@ -2131,35 +2131,35 @@ switch:
   # If room thermostat is enabled, controlling this switch will be done by the heatpump. In other words,
   # the room thermostat will decide when this will be on or off.
   - platform: template
-    name: "Water Flow Temperature Control Zone 1"        #"Power Heat/Cool Control Zone 1"
+    name: "Water Flow Temperature Control Zone 1"
     id: "${devicename}_water_flow_temperature_control_zone_1"
     icon: mdi:eye
     entity_category: config
     restore_mode: DISABLED
     optimistic : true
-    lambda: "return (id(unmasked_value_register_0) & 0x2) == 0x2; //return bit 0x2 status"
+    lambda: "return (id(unmasked_value_register_0) & 0x2) == 0x2; // Return bit 0x2 status"
     on_turn_on:
-      #- logger.log: "Switch Turned On!"
+      # - logger.log: "Switch Turned On!"
       - lambda: |-
-          uint16_t checked_bit = 0x2;                          //affected bit number
+          uint16_t checked_bit = 0x2;                          // Affected bit number
           uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
-          new_value &= ~checked_bit;                           //Clear and set
+          new_value &= ~checked_bit;                           // Clear and set
           new_value += checked_bit;
           if ((new_value) != id(unmasked_value_register_0)) {
-            //write new value to heatpump if changed
-            ESP_LOGI("unmasked_value_register_0", "Set option to on power_heat_cool_control_zone1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            // Write new value to heatpump if changed
+            # ESP_LOGD("unmasked_value_register_0", "Set option to on power_heat_cool_control_zone1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
             id(unmasked_value_register_0) = new_value;
             esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
             ${devicename}->queue_command(set_payload_command);
           }
     on_turn_off:
-      #- logger.log: "Switch Turned Off!"    
+      # - logger.log: "Switch Turned Off!"    
       - lambda: |-
           uint16_t checked_bit = 0x2;
           uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
-          new_value &= ~checked_bit;         //Clear and set
+          new_value &= ~checked_bit;         // Clear and set
           if ((new_value) != id(unmasked_value_register_0)) {
-            ESP_LOGI("unmasked_value_register_0", "Set option to off power_heat_cool_control_zone1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            # ESP_LOGD("unmasked_value_register_0", "Set option to off power_heat_cool_control_zone1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
             id(unmasked_value_register_0) = new_value;
             esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
             ${devicename}->queue_command(set_payload_command);
@@ -2173,31 +2173,29 @@ switch:
     restore_mode: DISABLED
     optimistic : true
     lambda:  |-
-        bool state_dhw = (id(unmasked_value_register_0) & 0x4) == 0x4;
-        // if (state_dhw) id(manually_disabled_dhw_heating_timestamp) = 0; else if (id(manually_disabled_dhw_heating_timestamp) == 0) id(manually_disabled_dhw_heating_timestamp) = id(esptime).now().timestamp;
-        return state_dhw;
+        return (id(unmasked_value_register_0) & 0x4) == 0x4;
     on_turn_on:
-      #- logger.log: "Switch Turned On!"
+      # - logger.log: "Switch Turned On!"
       - lambda: |-
           uint16_t checked_bit = 0x4;
           uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
-          new_value &= ~checked_bit;                           //Clear and set
+          new_value &= ~checked_bit;                           // Clear and set
           new_value += checked_bit;
           if ((new_value) != id(unmasked_value_register_0)) {
-            ESP_LOGI("unmasked_value_register_0", "Set option to on power_dhw_t5s 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            # ESP_LOGD("unmasked_value_register_0", "Set option to on power_dhw_t5s 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
             id(unmasked_value_register_0) = new_value;
             esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
             ${devicename}->queue_command(set_payload_command);
           }
     on_turn_off:
-      #- logger.log: "Switch Turned Off!"    
+      # - logger.log: "Switch Turned Off!"    
       - lambda: |-
           uint16_t checked_bit = 0x4;
           uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
-          new_value &= ~checked_bit;         //Clear and set
+          new_value &= ~checked_bit;         // Clear and set
           
           if ((new_value) != id(unmasked_value_register_0)) {
-            ESP_LOGI("unmasked_value_register_0", "Set option to off power_dhw_t5s 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            # ESP_LOGD("unmasked_value_register_0", "Set option to off power_dhw_t5s 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
             id(unmasked_value_register_0) = new_value;
             esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
             ${devicename}->queue_command(set_payload_command);
@@ -2209,7 +2207,7 @@ switch:
   # If room thermostat is enabled, controlling this switch will be done by the heatpump. In other words,
   # the room thermostat will decide when this will be on or off.
   - platform: template
-    name: "Water Flow Temperature Control Zone 2"          #"Power Heat Control Zone 2"
+    name: "Water Flow Temperature Control Zone 2"
     id: "${devicename}_water_flow_temperature_control_zone_2"
     icon: mdi:eye
     entity_category: config
@@ -2217,27 +2215,27 @@ switch:
     optimistic : true
     lambda: "return (id(unmasked_value_register_0) & 0x8) == 0x8;"
     on_turn_on:
-      #- logger.log: "Switch Turned On!"
+      # - logger.log: "Switch Turned On!"
       - lambda: |-
           uint16_t checked_bit = 0x8;
           uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
-          new_value &= ~checked_bit;         //Clear and set
+          new_value &= ~checked_bit;         // Clear and set
           new_value += checked_bit;
           if ((new_value) != id(unmasked_value_register_0)) {
-            ESP_LOGI("unmasked_value_register_0", "Set option to on power_air_conditioner_zone_2 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            # ESP_LOGD("unmasked_value_register_0", "Set option to on power_air_conditioner_zone_2 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
             id(unmasked_value_register_0) = new_value;
             esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
             ${devicename}->queue_command(set_payload_command);
           }
     on_turn_off:
-      #- logger.log: "Switch Turned Off!"    
+      # - logger.log: "Switch Turned Off!"    
       - lambda: |-
           uint16_t checked_bit = 0x8;
           uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
-          new_value &= ~checked_bit;         //Clear and set
+          new_value &= ~checked_bit;         // Clear and set
           
           if ((new_value) != id(unmasked_value_register_0)) {
-            ESP_LOGI("unmasked_value_register_0", "Set option to off power_air_conditioner_zone_2 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            # ESP_LOGD("unmasked_value_register_0", "Set option to off power_air_conditioner_zone_2 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
             id(unmasked_value_register_0) = new_value;
             esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
             ${devicename}->queue_command(set_payload_command);

--- a/heatpump.yaml
+++ b/heatpump.yaml
@@ -1093,7 +1093,7 @@ binary_sensor:
   # Bit: 1 -> Is present in this config as a 'switch'
   # Bit: 2 -> Is present in this config as a 'switch'
   # Bit: 3 -> Is present in this config as a 'switch'
-  # Bit: 4 -> not used
+  # Bit: 4 
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
     name: "Power Reserved BIT 4"
@@ -1102,7 +1102,7 @@ binary_sensor:
     register_type: holding
     address: 0x0
     bitmask: 0x10
-  # Bit: 5 -> not used
+  # Bit: 5 
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
     name: "Power Reserved BIT 5"
@@ -1111,7 +1111,7 @@ binary_sensor:
     register_type: holding
     address: 0x0
     bitmask: 0x20
-  # Bit: 6 -> not used
+  # Bit: 6 
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
     name: "Power Reserved BIT 6"
@@ -1120,7 +1120,7 @@ binary_sensor:
     register_type: holding
     address: 0x0
     bitmask: 0x40
-  # Bit: 7 -> not used
+  # Bit: 7 
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
     name: "Power Reserved BIT 7"
@@ -1129,7 +1129,7 @@ binary_sensor:
     register_type: holding
     address: 0x0
     bitmask: 0x80
-  # Bit: 8 -> not used
+  # Bit: 8 
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
     name: "Power Reserved BIT 8"
@@ -1138,7 +1138,7 @@ binary_sensor:
     register_type: holding
     address: 0x0
     bitmask: 0x100
-  # Bit: 9 -> not used
+  # Bit: 9 
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
     name: "Power Reserved BIT 9"
@@ -1147,7 +1147,7 @@ binary_sensor:
     register_type: holding
     address: 0x0
     bitmask: 0x200
-  # Bit: 10 -> not used
+  # Bit: 10 
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
     name: "Power Reserved BIT 10"
@@ -1156,7 +1156,7 @@ binary_sensor:
     register_type: holding
     address: 0x0
     bitmask: 0x400
-  # Bit: 11 -> not used
+  # Bit: 11 
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
     name: "Power Reserved BIT 11"
@@ -1165,7 +1165,7 @@ binary_sensor:
     register_type: holding
     address: 0x0
     bitmask: 0x800
-  # Bit: 12 -> not used
+  # Bit: 12 
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
     name: "Power Reserved BIT 12"
@@ -1174,7 +1174,7 @@ binary_sensor:
     register_type: holding
     address: 0x0
     bitmask: 0x1000
-  # Bit: 13 -> not used
+  # Bit: 13 
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
     name: "Power Reserved BIT 13"
@@ -1183,7 +1183,7 @@ binary_sensor:
     register_type: holding
     address: 0x0
     bitmask: 0x2000
-  # Bit: 14 -> not used
+  # Bit: 14 
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
     name: "Power Reserved BIT 14"
@@ -1192,7 +1192,7 @@ binary_sensor:
     register_type: holding
     address: 0x0
     bitmask: 0x4000
-  # Bit: 15 -> not used
+  # Bit: 15 
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
     name: "Power Reserved BIT 15"

--- a/heatpump.yaml
+++ b/heatpump.yaml
@@ -3,20 +3,24 @@ substitutions:
   description: Heatpump Controller
 
 globals:
+  - id: unmasked_value_register_0
+    type: uint16_t
+    restore_value: true
+    # initial_value: '0'
   - id: unmasked_value_water_temperature_t1s
-    type: int
+    type: uint16_t
     restore_value: no
     initial_value: '0'
   - id: unmasked_curve_selection
-    type: int
+    type: uint16_t
     restore_value: no
     initial_value: '0'
   - id: unmasked_value_register_270
-    type: int
+    type: uint16_t
     restore_value: no
     initial_value: '0'
   - id: unmasked_value_register_272
-    type: int
+    type: uint16_t
     restore_value: no
     initial_value: '0'
 
@@ -319,6 +323,20 @@ sensor:
     name: Uptime
     id: "${devicename}_uptime"
     icon: mdi:timelapse
+  # Register: 0 -> Config is present as select, but now we need get value from heatpump and save it as global var
+  - platform: modbus_controller
+    modbus_controller_id: "${devicename}"
+    name: "Register 0 switches"
+    id: "${devicename}_register_0_switches"
+    internal: true
+    register_type: holding
+    address: 0x0
+    value_type: U_WORD
+    icon: mdi:eye
+    lambda: |-
+      // Update the global var unmasked_value_register_0
+      id(unmasked_value_register_0) = x;
+      return x;    
   # Register: 1 -> Is present in this config as a 'select'
   # Register: 2 -> Is present in this config as a 'number'
   # Register: 3
@@ -1070,119 +1088,119 @@ sensor:
       return t1s_dhw;
 
 binary_sensor:
-  # Register: 0
+  # Register: 0 ->Is read as sensor from modbus to be fully switch functiuoning
   # Bit: 0 -> Is present in this config as a 'switch'
   # Bit: 1 -> Is present in this config as a 'switch'
   # Bit: 2 -> Is present in this config as a 'switch'
   # Bit: 3 -> Is present in this config as a 'switch'
-  # Bit: 4
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Power Reserved BIT 4"
-    id: "${devicename}_power_reserved_bit_4"
-    icon: mdi:head-question-outline
-    register_type: holding
-    address: 0x0
-    bitmask: 0x10
-  # Bit: 5
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Power Reserved BIT 5"
-    id: "${devicename}_power_reserved_bit_5"
-    icon: mdi:head-question-outline
-    register_type: holding
-    address: 0x0
-    bitmask: 0x20
-  # Bit: 6
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Power Reserved BIT 6"
-    id: "${devicename}_power_reserved_bit_6"
-    icon: mdi:head-question-outline
-    register_type: holding
-    address: 0x0
-    bitmask: 0x40
-  # Bit: 7
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Power Reserved BIT 7"
-    id: "${devicename}_power_reserved_bit_7"
-    icon: mdi:head-question-outline
-    register_type: holding
-    address: 0x0
-    bitmask: 0x80
-  # Bit: 8
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Power Reserved BIT 8"
-    id: "${devicename}_power_reserved_bit_8"
-    icon: mdi:head-question-outline
-    register_type: holding
-    address: 0x0
-    bitmask: 0x100
-  # Bit: 9
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Power Reserved BIT 9"
-    id: "${devicename}_power_reserved_bit_9"
-    icon: mdi:head-question-outline
-    register_type: holding
-    address: 0x0
-    bitmask: 0x200
-  # Bit: 10
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Power Reserved BIT 10"
-    id: "${devicename}_power_reserved_bit_10"
-    icon: mdi:head-question-outline
-    register_type: holding
-    address: 0x0
-    bitmask: 0x400
-  # Bit: 11
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Power Reserved BIT 11"
-    id: "${devicename}_power_reserved_bit_11"
-    icon: mdi:head-question-outline
-    register_type: holding
-    address: 0x0
-    bitmask: 0x800
-  # Bit: 12
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Power Reserved BIT 12"
-    id: "${devicename}_power_reserved_bit_12"
-    icon: mdi:head-question-outline
-    register_type: holding
-    address: 0x0
-    bitmask: 0x1000
-  # Bit: 13
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Power Reserved BIT 13"
-    id: "${devicename}_power_reserved_bit_13"
-    icon: mdi:head-question-outline
-    register_type: holding
-    address: 0x0
-    bitmask: 0x2000
-  # Bit: 14
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Power Reserved BIT 14"
-    id: "${devicename}_power_reserved_bit_14"
-    icon: mdi:head-question-outline
-    register_type: holding
-    address: 0x0
-    bitmask: 0x4000
-  # Bit: 15
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Power Reserved BIT 15"
-    id: "${devicename}_power_reserved_bit_15"
-    icon: mdi:head-question-outline
-    register_type: holding
-    address: 0x0
-    bitmask: 0x8000
+  # Bit: 4 -> not used
+  # - platform: modbus_controller
+  #   modbus_controller_id: "${devicename}"
+  #   name: "Power Reserved BIT 4"
+  #   id: "${devicename}_power_reserved_bit_4"
+  #   icon: mdi:head-question-outline
+  #   register_type: holding
+  #   address: 0x0
+  #   bitmask: 0x10
+  # Bit: 5 -> not used
+  # - platform: modbus_controller
+  #   modbus_controller_id: "${devicename}"
+  #   name: "Power Reserved BIT 5"
+  #   id: "${devicename}_power_reserved_bit_5"
+  #   icon: mdi:head-question-outline
+  #   register_type: holding
+  #   address: 0x0
+  #   bitmask: 0x20
+  # Bit: 6 -> not used
+  # - platform: modbus_controller
+  #   modbus_controller_id: "${devicename}"
+  #   name: "Power Reserved BIT 6"
+  #   id: "${devicename}_power_reserved_bit_6"
+  #   icon: mdi:head-question-outline
+  #   register_type: holding
+  #   address: 0x0
+  #   bitmask: 0x40
+  # Bit: 7 -> not used
+  # - platform: modbus_controller
+  #   modbus_controller_id: "${devicename}"
+  #   name: "Power Reserved BIT 7"
+  #   id: "${devicename}_power_reserved_bit_7"
+  #   icon: mdi:head-question-outline
+  #   register_type: holding
+  #   address: 0x0
+  #   bitmask: 0x80
+  # Bit: 8 -> not used
+  # - platform: modbus_controller
+  #   modbus_controller_id: "${devicename}"
+  #   name: "Power Reserved BIT 8"
+  #   id: "${devicename}_power_reserved_bit_8"
+  #   icon: mdi:head-question-outline
+  #   register_type: holding
+  #   address: 0x0
+  #   bitmask: 0x100
+  # Bit: 9 -> not used
+  # - platform: modbus_controller
+  #   modbus_controller_id: "${devicename}"
+  #   name: "Power Reserved BIT 9"
+  #   id: "${devicename}_power_reserved_bit_9"
+  #   icon: mdi:head-question-outline
+  #   register_type: holding
+  #   address: 0x0
+  #   bitmask: 0x200
+  # Bit: 10 -> not used
+  # - platform: modbus_controller
+  #   modbus_controller_id: "${devicename}"
+  #   name: "Power Reserved BIT 10"
+  #   id: "${devicename}_power_reserved_bit_10"
+  #   icon: mdi:head-question-outline
+  #   register_type: holding
+  #   address: 0x0
+  #   bitmask: 0x400
+  # Bit: 11 -> not used
+  # - platform: modbus_controller
+  #   modbus_controller_id: "${devicename}"
+  #   name: "Power Reserved BIT 11"
+  #   id: "${devicename}_power_reserved_bit_11"
+  #   icon: mdi:head-question-outline
+  #   register_type: holding
+  #   address: 0x0
+  #   bitmask: 0x800
+  # Bit: 12 -> not used
+  # - platform: modbus_controller
+  #   modbus_controller_id: "${devicename}"
+  #   name: "Power Reserved BIT 12"
+  #   id: "${devicename}_power_reserved_bit_12"
+  #   icon: mdi:head-question-outline
+  #   register_type: holding
+  #   address: 0x0
+  #   bitmask: 0x1000
+  # Bit: 13 -> not used
+  # - platform: modbus_controller
+  #   modbus_controller_id: "${devicename}"
+  #   name: "Power Reserved BIT 13"
+  #   id: "${devicename}_power_reserved_bit_13"
+  #   icon: mdi:head-question-outline
+  #   register_type: holding
+  #   address: 0x0
+  #   bitmask: 0x2000
+  # Bit: 14 -> not used
+  # - platform: modbus_controller
+  #   modbus_controller_id: "${devicename}"
+  #   name: "Power Reserved BIT 14"
+  #   id: "${devicename}_power_reserved_bit_14"
+  #   icon: mdi:head-question-outline
+  #   register_type: holding
+  #   address: 0x0
+  #   bitmask: 0x4000
+  # Bit: 15 -> not used
+  # - platform: modbus_controller
+  #   modbus_controller_id: "${devicename}"
+  #   name: "Power Reserved BIT 15"
+  #   id: "${devicename}_power_reserved_bit_15"
+  #   icon: mdi:head-question-outline
+  #   register_type: holding
+  #   address: 0x0
+  #   bitmask: 0x8000
 
   # Register: 5
   # Bit: 0
@@ -2073,52 +2091,157 @@ switch:
   # Register: 0 -> Bit 0
   # When Room Temperature Control is enabled, the temperature sensor in the remote controller
   # will be used to define when the heatpump should be turned (powered) on or off
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Room Temperature Control"
+  - platform: template
+    name: "Room Temperature Control"                  #"Power Climate Control -uses FanCoilUnit as emission type"
     id: "${devicename}_room_temperature_control"
     icon: mdi:eye
-    register_type: holding
-    address: 0x0
-    bitmask: 0x1
+    entity_category: config
+    restore_mode: DISABLED
+    optimistic : true
+    lambda: "return (id(unmasked_value_register_0) & 0x1) == 0x1;"
+    on_turn_on:
+      #- logger.log: "Switch Turned On!"
+      - lambda: |-
+          uint16_t checked_bit = 0x1;
+          uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
+          new_value &= ~checked_bit;         //Clear and set
+          new_value += checked_bit;
+          if ((new_value) != id(unmasked_value_register_0)) {
+            ESP_LOGI("unmasked_value_register_0", "Set option to on power_air_conditioner_zone_1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            id(unmasked_value_register_0) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
+    on_turn_off:
+      #- logger.log: "Switch Turned Off!"    
+      - lambda: |-
+          uint16_t checked_bit = 0x1;
+          uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
+          new_value &= ~checked_bit;         //Clear and set
+          if ((new_value) != id(unmasked_value_register_0)) {
+            ESP_LOGI("unmasked_value_register_0", "Set option to off power_air_conditioner_zone_1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            id(unmasked_value_register_0) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
   # Register: 0 -> Bit 1
   # When Water Flow Temperature Control is enabled for thise zone, the target outlet water temperature
   # will be used to define when the heatpump should be turned (powered) on or off
   #
   # If room thermostat is enabled, controlling this switch will be done by the heatpump. In other words,
   # the room thermostat will decide when this will be on or off.
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Water Flow Temperature Control Zone 1"
+  - platform: template
+    name: "Water Flow Temperature Control Zone 1"        #"Power Heat/Cool Control Zone 1"
     id: "${devicename}_water_flow_temperature_control_zone_1"
     icon: mdi:eye
-    register_type: holding
-    address: 0x0
-    bitmask: 0x2
-  # Register: 0 -> Bit 2
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
+    entity_category: config
+    restore_mode: DISABLED
+    optimistic : true
+    lambda: "return (id(unmasked_value_register_0) & 0x2) == 0x2; //return bit 0x2 status"
+    on_turn_on:
+      #- logger.log: "Switch Turned On!"
+      - lambda: |-
+          uint16_t checked_bit = 0x2;                          //affected bit number
+          uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
+          new_value &= ~checked_bit;                           //Clear and set
+          new_value += checked_bit;
+          if ((new_value) != id(unmasked_value_register_0)) {
+            //write new value to heatpump if changed
+            ESP_LOGI("unmasked_value_register_0", "Set option to on power_heat_cool_control_zone1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            id(unmasked_value_register_0) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
+    on_turn_off:
+      #- logger.log: "Switch Turned Off!"    
+      - lambda: |-
+          uint16_t checked_bit = 0x2;
+          uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
+          new_value &= ~checked_bit;         //Clear and set
+          if ((new_value) != id(unmasked_value_register_0)) {
+            ESP_LOGI("unmasked_value_register_0", "Set option to off power_heat_cool_control_zone1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            id(unmasked_value_register_0) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
+  # Register: 0 -> Bit 2 DHW
+  - platform: template
     name: "Power DHW T5S"
     id: "${devicename}_power_dhw_t5s"
     icon: mdi:eye
-    register_type: holding
     entity_category: config
-    address: 0x0
-    bitmask: 0x4
+    restore_mode: DISABLED
+    optimistic : true
+    lambda:  |-
+        bool state_dhw = (id(unmasked_value_register_0) & 0x4) == 0x4;
+        // if (state_dhw) id(manually_disabled_dhw_heating_timestamp) = 0; else if (id(manually_disabled_dhw_heating_timestamp) == 0) id(manually_disabled_dhw_heating_timestamp) = id(esptime).now().timestamp;
+        return state_dhw;
+    on_turn_on:
+      #- logger.log: "Switch Turned On!"
+      - lambda: |-
+          uint16_t checked_bit = 0x4;
+          uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
+          new_value &= ~checked_bit;                           //Clear and set
+          new_value += checked_bit;
+          if ((new_value) != id(unmasked_value_register_0)) {
+            ESP_LOGI("unmasked_value_register_0", "Set option to on power_dhw_t5s 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            id(unmasked_value_register_0) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
+    on_turn_off:
+      #- logger.log: "Switch Turned Off!"    
+      - lambda: |-
+          uint16_t checked_bit = 0x4;
+          uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
+          new_value &= ~checked_bit;         //Clear and set
+          
+          if ((new_value) != id(unmasked_value_register_0)) {
+            ESP_LOGI("unmasked_value_register_0", "Set option to off power_dhw_t5s 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            id(unmasked_value_register_0) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
   # Register: 0 -> Bit 3
   # When Water Flow Temperature Control is enabled for thise zone, the target outlet water temperature
   # will be used to define when the heatpump should be turned (powered) on or off
   #
   # If room thermostat is enabled, controlling this switch will be done by the heatpump. In other words,
   # the room thermostat will decide when this will be on or off.
-  - platform: modbus_controller
-    modbus_controller_id: "${devicename}"
-    name: "Water Flow Temperature Control Zone 2"
+  - platform: template
+    name: "Water Flow Temperature Control Zone 2"          #"Power Heat Control Zone 2"
     id: "${devicename}_water_flow_temperature_control_zone_2"
     icon: mdi:eye
-    register_type: holding
-    address: 0x0
-    bitmask: 0x8
+    entity_category: config
+    restore_mode: DISABLED
+    optimistic : true
+    lambda: "return (id(unmasked_value_register_0) & 0x8) == 0x8;"
+    on_turn_on:
+      #- logger.log: "Switch Turned On!"
+      - lambda: |-
+          uint16_t checked_bit = 0x8;
+          uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
+          new_value &= ~checked_bit;         //Clear and set
+          new_value += checked_bit;
+          if ((new_value) != id(unmasked_value_register_0)) {
+            ESP_LOGI("unmasked_value_register_0", "Set option to on power_air_conditioner_zone_2 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            id(unmasked_value_register_0) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
+    on_turn_off:
+      #- logger.log: "Switch Turned Off!"    
+      - lambda: |-
+          uint16_t checked_bit = 0x8;
+          uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
+          new_value &= ~checked_bit;         //Clear and set
+          
+          if ((new_value) != id(unmasked_value_register_0)) {
+            ESP_LOGI("unmasked_value_register_0", "Set option to off power_air_conditioner_zone_2 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            id(unmasked_value_register_0) = new_value;
+            esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
+            ${devicename}->queue_command(set_payload_command);
+          }
   # Register: 5 -> Bit 12
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"

--- a/heatpump.yaml
+++ b/heatpump.yaml
@@ -2107,7 +2107,7 @@ switch:
           new_value &= ~checked_bit;         // Clear and set
           new_value += checked_bit;
           if ((new_value) != id(unmasked_value_register_0)) {
-            # ESP_LOGD("unmasked_value_register_0", "Set option to on power_air_conditioner_zone_1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            // ESP_LOGD("unmasked_value_register_0", "Set option to on power_air_conditioner_zone_1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
             id(unmasked_value_register_0) = new_value;
             esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
             ${devicename}->queue_command(set_payload_command);
@@ -2119,7 +2119,7 @@ switch:
           uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
           new_value &= ~checked_bit;         // Clear and set
           if ((new_value) != id(unmasked_value_register_0)) {
-            # ESP_LOGD("unmasked_value_register_0", "Set option to off power_air_conditioner_zone_1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            // ESP_LOGD("unmasked_value_register_0", "Set option to off power_air_conditioner_zone_1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
             id(unmasked_value_register_0) = new_value;
             esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
             ${devicename}->queue_command(set_payload_command);
@@ -2147,7 +2147,7 @@ switch:
           new_value += checked_bit;
           if ((new_value) != id(unmasked_value_register_0)) {
             // Write new value to heatpump if changed
-            # ESP_LOGD("unmasked_value_register_0", "Set option to on power_heat_cool_control_zone1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            // ESP_LOGD("unmasked_value_register_0", "Set option to on power_heat_cool_control_zone1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
             id(unmasked_value_register_0) = new_value;
             esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
             ${devicename}->queue_command(set_payload_command);
@@ -2159,7 +2159,7 @@ switch:
           uint16_t new_value = id(unmasked_value_register_0);  // The original unmasked value
           new_value &= ~checked_bit;         // Clear and set
           if ((new_value) != id(unmasked_value_register_0)) {
-            # ESP_LOGD("unmasked_value_register_0", "Set option to off power_heat_cool_control_zone1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            // ESP_LOGD("unmasked_value_register_0", "Set option to off power_heat_cool_control_zone1 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
             id(unmasked_value_register_0) = new_value;
             esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
             ${devicename}->queue_command(set_payload_command);
@@ -2182,7 +2182,7 @@ switch:
           new_value &= ~checked_bit;                           // Clear and set
           new_value += checked_bit;
           if ((new_value) != id(unmasked_value_register_0)) {
-            # ESP_LOGD("unmasked_value_register_0", "Set option to on power_dhw_t5s 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            // ESP_LOGD("unmasked_value_register_0", "Set option to on power_dhw_t5s 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
             id(unmasked_value_register_0) = new_value;
             esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
             ${devicename}->queue_command(set_payload_command);
@@ -2195,7 +2195,7 @@ switch:
           new_value &= ~checked_bit;         // Clear and set
           
           if ((new_value) != id(unmasked_value_register_0)) {
-            # ESP_LOGD("unmasked_value_register_0", "Set option to off power_dhw_t5s 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            // ESP_LOGD("unmasked_value_register_0", "Set option to off power_dhw_t5s 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
             id(unmasked_value_register_0) = new_value;
             esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
             ${devicename}->queue_command(set_payload_command);
@@ -2222,7 +2222,7 @@ switch:
           new_value &= ~checked_bit;         // Clear and set
           new_value += checked_bit;
           if ((new_value) != id(unmasked_value_register_0)) {
-            # ESP_LOGD("unmasked_value_register_0", "Set option to on power_air_conditioner_zone_2 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            // ESP_LOGD("unmasked_value_register_0", "Set option to on power_air_conditioner_zone_2 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
             id(unmasked_value_register_0) = new_value;
             esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
             ${devicename}->queue_command(set_payload_command);
@@ -2235,7 +2235,7 @@ switch:
           new_value &= ~checked_bit;         // Clear and set
           
           if ((new_value) != id(unmasked_value_register_0)) {
-            # ESP_LOGD("unmasked_value_register_0", "Set option to off power_air_conditioner_zone_2 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
+            // ESP_LOGD("unmasked_value_register_0", "Set option to off power_air_conditioner_zone_2 0x%x -> 0x%x", id(unmasked_value_register_0), new_value);
             id(unmasked_value_register_0) = new_value;
             esphome::modbus_controller::ModbusCommandItem set_payload_command = esphome::modbus_controller::ModbusCommandItem::create_write_single_command(${devicename}, 0x0, new_value);
             ${devicename}->queue_command(set_payload_command);


### PR DESCRIPTION
Update Register 0 to be fully configurable (previously was impossible to set more than 1 option select. Commented reserved bits of register 0 -why make garbage in HA -better is leave code as commented for future -if there will be need to add functionality when producer implement it. Changed globasl from int to uint16_t -same as modbus register values