### PR TITLE
Updated included web-UI layout

### DIFF
--- a/heatpump.yaml
+++ b/heatpump.yaml
@@ -59,6 +59,7 @@ api:
 
 web_server:
   port: 80
+  version: 3
 
 ota:
   platform: esphome


### PR DESCRIPTION
Updated included web-UI layout.
By default ESPHome ships with version 2 which uses web components and version 3 uses HA-Styling.
This change is to de-clutter the default interface and split it into sections, which is more user-friendly.

![image](https://github.com/user-attachments/assets/95c84ceb-a372-4af9-9cee-fa4084ccfaf0)
