### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Changed
+- Duplicated register 4 defined as sensor and number. Removed from sensor config.
+  
 ## [5.0.0] - 2024-11-24
 
 ### Changed


### PR DESCRIPTION
duplicated register 4 defined as sensor and number. Removed from sensor config

;) -I've implemented in my branch: https://github.com/rysiulg/Midea-heat-pump-ESPHome/tree/master-york-with-automations in version numbering when creating version automatically change version in heatpump.yaml and changelog.md and also prepare and add lines defined new changes like [Unreleased] and next line changed -this is for convinient purpose and easly create versions, also you don't forget to add these lines after create new version or just before create version. 
Why waste place in our memoriy? ;)