### PR TITLE
tracking compressor start events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Register 3 has been changed from type `sensor` to `number` to make them configurable
 - Updated with device class and state class, for better compatibility in Home Assistant sensors. With this modification, you can now compare temperatures on a graph, for example, under Home Assistant.
+- Introduced a `binary_sensor` to detect when the compressor is running based on operating frequency > 0.
+- Counted compressor start events by monitoring transitions from OFF → ON.
+- Added a `template sensor` to expose the number of starts per hour (`starts/h`).
+- Automatically resets the counter every hour.
 
 ## [5.1.0] - 2025-01-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Register 3 has been changed from type `sensor` to `number` to make them configurable
+- Updated with device class and state class, for better compatibility in Home Assistant sensors. With this modification, you can now compare temperatures on a graph, for example, under Home Assistant.
 
 ## [5.1.0] - 2025-01-12
 

--- a/heatpump.yaml
+++ b/heatpump.yaml
@@ -3160,7 +3160,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 5
     max_value: 60
@@ -3199,7 +3198,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 5
     max_value: 60
@@ -3235,7 +3233,6 @@ number:
     address: 0x3
     value_type: U_WORD
     unit_of_measurement: "°C"
-    state_class: "measurement"
     entity_category: config
     device_class: temperature
     min_value: 17
@@ -3258,7 +3255,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 20
     max_value: 65
@@ -3365,7 +3361,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 1
     max_value: 30
@@ -3380,7 +3375,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 5
     max_value: 40
@@ -3408,7 +3402,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 35
     max_value: 43
@@ -3423,7 +3416,6 @@ number:
     value_type: S_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: -25
     max_value: 5
@@ -3453,7 +3445,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 0
     max_value: 10
@@ -3468,7 +3459,6 @@ number:
     value_type: S_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: -5
     max_value: 20
@@ -3483,7 +3473,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 60
     max_value: 70
@@ -3537,7 +3526,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 2
     max_value: 10
@@ -3552,7 +3540,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 1
     max_value: 10
@@ -3567,7 +3554,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 35
     max_value: 46
@@ -3582,7 +3568,6 @@ number:
     value_type: S_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: -5
     max_value: 25
@@ -3610,7 +3595,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 2
     max_value: 10
@@ -3625,7 +3609,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 1
     max_value: 10
@@ -3640,7 +3623,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 20
     max_value: 35
@@ -3655,7 +3637,6 @@ number:
     value_type: S_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: -25
     max_value: 5
@@ -3670,7 +3651,6 @@ number:
     value_type: S_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: -15
     max_value: 10
@@ -3685,7 +3665,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 1
     max_value: 7
@@ -3713,7 +3692,6 @@ number:
     value_type: S_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: -15
     max_value: 10
@@ -3728,7 +3706,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 1
     max_value: 7
@@ -3782,7 +3759,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 20
     max_value: 29
@@ -3797,7 +3773,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 10
     max_value: 17
@@ -3812,7 +3787,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 20
     max_value: 29
@@ -3827,7 +3801,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 20
     max_value: 25
@@ -3868,7 +3841,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 0
     max_value: 50
@@ -3961,7 +3933,6 @@ number:
     value_type: S_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 30
     max_value: 55
@@ -3989,7 +3960,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 25
     max_value: 35
@@ -4004,7 +3974,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 5
     max_value: 25
@@ -4019,7 +3988,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 5
     max_value: 25
@@ -4034,7 +4002,6 @@ number:
     value_type: S_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: -5
     max_value: 46
@@ -4049,7 +4016,6 @@ number:
     value_type: S_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: -5
     max_value: 46
@@ -4064,7 +4030,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 25
     max_value: 65
@@ -4079,7 +4044,6 @@ number:
     value_type: U_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: 25
     max_value: 65
@@ -4094,7 +4058,6 @@ number:
     value_type: S_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: -25
     max_value: 30
@@ -4109,7 +4072,6 @@ number:
     value_type: S_WORD
     unit_of_measurement: "°C"
     device_class: "temperature"
-    state_class: "measurement"
     entity_category: config
     min_value: -25
     max_value: 30

--- a/heatpump.yaml
+++ b/heatpump.yaml
@@ -411,6 +411,8 @@ sensor:
     address: 0x64
     value_type: U_WORD
     unit_of_measurement: Hz
+    device_class: "frequency"
+    state_class: "measurement"
   # Register: 101 -> Is present in this config as a 'text_sensor'
   # Register: 102
   - platform: modbus_controller
@@ -447,6 +449,8 @@ sensor:
     address: 0x68
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
   # Register: 105
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
@@ -457,6 +461,8 @@ sensor:
     address: 0x69
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
   # Register: 106
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
@@ -467,6 +473,8 @@ sensor:
     address: 0x6a
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
   # Register: 107
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
@@ -476,6 +484,8 @@ sensor:
     register_type: holding
     address: 0x6B
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     value_type: S_WORD
   # Register: 108
   - platform: modbus_controller
@@ -487,6 +497,8 @@ sensor:
     address: 0x6c
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
   # Register: 109
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
@@ -497,6 +509,8 @@ sensor:
     address: 0x6d
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
   # Register: 110
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
@@ -507,6 +521,8 @@ sensor:
     address: 0x6e
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
   # Register: 111
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
@@ -517,6 +533,8 @@ sensor:
     address: 0x6f
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
   # Register: 112
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
@@ -527,6 +545,8 @@ sensor:
     address: 0x70
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
   # Register: 113
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
@@ -537,6 +557,8 @@ sensor:
     address: 0x71
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
   # Register: 114
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
@@ -547,6 +569,8 @@ sensor:
     address: 0x72
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
   # Register: 115
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
@@ -556,6 +580,8 @@ sensor:
     register_type: holding
     address: 0x73
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     value_type: S_WORD
   # Register: 116
   - platform: modbus_controller
@@ -567,6 +593,8 @@ sensor:
     address: 0x74
     value_type: U_WORD
     unit_of_measurement: kPA
+    device_class: "pressure"
+    state_class: "measurement"
   # Register: 117
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
@@ -577,6 +605,8 @@ sensor:
     address: 0x75
     value_type: U_WORD
     unit_of_measurement: kPA
+    device_class: "pressure"
+    state_class: "measurement"
   # Register: 118
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
@@ -587,6 +617,8 @@ sensor:
     address: 0x76
     value_type: U_WORD
     unit_of_measurement: A
+    device_class: "current"
+    state_class: "measurement"
   # Register: 119
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
@@ -597,6 +629,8 @@ sensor:
     address: 0x77
     value_type: U_WORD
     unit_of_measurement: V
+    device_class: "voltage"
+    state_class: "measurement"
   # Register: 120
   # Midea: Tbt1
   - platform: modbus_controller
@@ -605,6 +639,8 @@ sensor:
     id: "${devicename}_hydraulic_module_current_1"
     icon: mdi:thermometer
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     register_type: holding
     address: 0x78
     value_type: U_WORD
@@ -616,6 +652,8 @@ sensor:
     id: "${devicename}_hydraulic_module_current_2"
     icon: mdi:thermometer
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     register_type: holding
     address: 0x79
     value_type: U_WORD
@@ -707,6 +745,8 @@ sensor:
     address: 0x84
     value_type: U_WORD
     unit_of_measurement: Hz
+    device_class: "frequency"
+    state_class: "measurement"
   # Register: 133
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
@@ -717,6 +757,8 @@ sensor:
     address: 0x85
     value_type: U_WORD
     unit_of_measurement: A
+    device_class: "current"
+    state_class: "measurement"
   # Register: 134
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
@@ -727,6 +769,8 @@ sensor:
     address: 0x86
     value_type: U_WORD
     unit_of_measurement: V
+    device_class: "voltage"
+    state_class: "measurement"
     filters:
       - multiply: 10
   # Register: 135
@@ -738,6 +782,8 @@ sensor:
     register_type: holding
     address: 0x87
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     value_type: S_WORD
   # Register: 136
   - platform: modbus_controller
@@ -749,6 +795,8 @@ sensor:
     address: 0x88
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
   # Register: 137
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
@@ -759,6 +807,8 @@ sensor:
     address: 0x89
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
   # Register: 138
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
@@ -805,6 +855,8 @@ sensor:
     address: 0x8d
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
   # Register: 143 and 144
   # U_DWORD combines this register with the next one
   - platform: modbus_controller
@@ -845,6 +897,8 @@ sensor:
     address: 0xc9
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     bitmask: 0x00FF
   # Register: 201 (High), default: 25, TODO: verify default
   - platform: modbus_controller
@@ -856,6 +910,8 @@ sensor:
     address: 0xc9
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     bitmask: 0xFF00
   # Register: 202 (Low), default: 5, TODO: verify default
   - platform: modbus_controller
@@ -867,6 +923,8 @@ sensor:
     address: 0xca
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     bitmask: 0x00FF
   # Register: 202 (High), default: 5, TODO: verify default
   - platform: modbus_controller
@@ -878,6 +936,8 @@ sensor:
     address: 0xca
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     bitmask: 0xFF00
   # Register: 203 (Low), default: 55, TODO: verify default
   - platform: modbus_controller
@@ -889,6 +949,8 @@ sensor:
     address: 0xcb
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     bitmask: 0x00FF
   # Register: 203 (High), default: 55, TODO: verify default
   - platform: modbus_controller
@@ -900,6 +962,8 @@ sensor:
     address: 0xcb
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     bitmask: 0xFF00
   # Register: 204 (Low), default: 25, TODO: verify default
   - platform: modbus_controller
@@ -911,6 +975,8 @@ sensor:
     address: 0xcc
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     bitmask: 0x00FF
   # Register: 204 (High), default: 25, TODO: verify default
   - platform: modbus_controller
@@ -922,6 +988,8 @@ sensor:
     address: 0xcc
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     bitmask: 0xFF00
   # Register: 205
   - platform: modbus_controller
@@ -933,6 +1001,8 @@ sensor:
     address: 0xcd
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     filters:
       - multiply: 0.5
   # Register: 206
@@ -945,6 +1015,8 @@ sensor:
     address: 0xce
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     filters:
       - multiply: 0.5
   # Register: 207
@@ -957,6 +1029,8 @@ sensor:
     address: 0xcf
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
   # Register: 208
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
@@ -967,6 +1041,8 @@ sensor:
     address: 0xd0
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
   # Register: 209 -> Is present in this config as a 'number'
   # Register: 210 -> Config is present as select, but now we need get value from heatpump and save it as global var
   - platform: modbus_controller
@@ -1078,6 +1154,8 @@ sensor:
     id: "${devicename}_t1s_dhw"
     icon: mdi:thermometer
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     lambda: |-
       int dt1s5 = id(${devicename}_dt1s5).state;
       int t5 = id(${devicename}_water_tank_temperature_t5).state;
@@ -3081,6 +3159,8 @@ number:
     address: 0x2
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 5
     max_value: 60
@@ -3118,6 +3198,8 @@ number:
     address: 0x2
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 5
     max_value: 60
@@ -3153,6 +3235,7 @@ number:
     address: 0x3
     value_type: U_WORD
     unit_of_measurement: "°C"
+    state_class: "measurement"
     entity_category: config
     device_class: temperature
     min_value: 17
@@ -3174,6 +3257,8 @@ number:
     address: 0x4
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 20
     max_value: 65
@@ -3279,6 +3364,8 @@ number:
     address: 0xd4
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 1
     max_value: 30
@@ -3292,6 +3379,8 @@ number:
     address: 0xd5
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 5
     max_value: 40
@@ -3318,6 +3407,8 @@ number:
     address: 0xd7
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 35
     max_value: 43
@@ -3331,6 +3422,8 @@ number:
     address: 0xd8
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: -25
     max_value: 5
@@ -3359,6 +3452,8 @@ number:
     address: 0xda
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 0
     max_value: 10
@@ -3372,6 +3467,8 @@ number:
     address: 0xdb
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: -5
     max_value: 20
@@ -3385,6 +3482,8 @@ number:
     address: 0xdc
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 60
     max_value: 70
@@ -3437,6 +3536,8 @@ number:
     address: 0xe0
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 2
     max_value: 10
@@ -3450,6 +3551,8 @@ number:
     address: 0xe1
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 1
     max_value: 10
@@ -3463,6 +3566,8 @@ number:
     address: 0xe2
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 35
     max_value: 46
@@ -3476,6 +3581,8 @@ number:
     address: 0xe3
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: -5
     max_value: 25
@@ -3502,6 +3609,8 @@ number:
     address: 0xe5
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 2
     max_value: 10
@@ -3515,6 +3624,8 @@ number:
     address: 0xe6
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 1
     max_value: 10
@@ -3528,6 +3639,8 @@ number:
     address: 0xe7
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 20
     max_value: 35
@@ -3541,6 +3654,8 @@ number:
     address: 0xe8
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: -25
     max_value: 5
@@ -3554,6 +3669,8 @@ number:
     address: 0xe9
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: -15
     max_value: 10
@@ -3567,6 +3684,8 @@ number:
     address: 0xea
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 1
     max_value: 7
@@ -3593,6 +3712,8 @@ number:
     address: 0xed
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: -15
     max_value: 10
@@ -3606,6 +3727,8 @@ number:
     address: 0xee
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 1
     max_value: 7
@@ -3658,6 +3781,8 @@ number:
     address: 0xf3
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 20
     max_value: 29
@@ -3671,6 +3796,8 @@ number:
     address: 0xf4
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 10
     max_value: 17
@@ -3684,6 +3811,8 @@ number:
     address: 0xf5
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 20
     max_value: 29
@@ -3697,6 +3826,8 @@ number:
     address: 0xf6
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 20
     max_value: 25
@@ -3736,6 +3867,8 @@ number:
     address: 0xf9
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 0
     max_value: 50
@@ -3827,6 +3960,8 @@ number:
     address: 0x102
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 30
     max_value: 55
@@ -3853,6 +3988,8 @@ number:
     address: 0x104
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 25
     max_value: 35
@@ -3866,6 +4003,8 @@ number:
     address: 0x105
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 5
     max_value: 25
@@ -3879,6 +4018,8 @@ number:
     address: 0x106
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 5
     max_value: 25
@@ -3892,6 +4033,8 @@ number:
     address: 0x107
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: -5
     max_value: 46
@@ -3905,6 +4048,8 @@ number:
     address: 0x108
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: -5
     max_value: 46
@@ -3918,6 +4063,8 @@ number:
     address: 0x109
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 25
     max_value: 65
@@ -3931,6 +4078,8 @@ number:
     address: 0x10a
     value_type: U_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: 25
     max_value: 65
@@ -3944,6 +4093,8 @@ number:
     address: 0x10b
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: -25
     max_value: 30
@@ -3957,6 +4108,8 @@ number:
     address: 0x10c
     value_type: S_WORD
     unit_of_measurement: "°C"
+    device_class: "temperature"
+    state_class: "measurement"
     entity_category: config
     min_value: -25
     max_value: 30

--- a/heatpump.yaml
+++ b/heatpump.yaml
@@ -35,6 +35,10 @@ globals:
     type: uint16_t
     restore_value: no
     initial_value: '0'
+  - id: compressor_start_count
+    type: int
+    restore_value: no
+    initial_value: '0'    
 
 esphome:
   name: "${devicename}"
@@ -315,6 +319,15 @@ select:
       return {};
 
 sensor:
+  - platform: template
+    name: "Compressor Starts Per Hour"
+    id: compressor_starts_per_hour
+    unit_of_measurement: "starts/h"
+    accuracy_decimals: 0
+    update_interval: 10s
+    lambda: |-
+      return id(compressor_start_count);
+
   - platform: uptime
     name: Uptime
     id: "${devicename}_uptime"
@@ -1190,6 +1203,13 @@ binary_sensor:
   # Bit: 2 -> Is present in this config as a 'switch'
   # Bit: 3 -> Is present in this config as a 'switch'
   # Bit: 4
+  - platform: template
+    name: "Compressor Running"
+    id: compressor_running
+    device_class: running
+    lambda: |-
+      return id(heatpump_compressor_operating_frequency).state > 0;
+  
   - platform: modbus_controller
     modbus_controller_id: "${devicename}"
     name: "Power Reserved BIT 4"
@@ -4646,3 +4666,21 @@ text_sensor:
            z = std::to_string((rawdata & 0x00F0) >> 4);
          }
          return {z};
+
+interval:
+  - interval: 1h
+    then:
+      - lambda: |-
+          id(compressor_start_count) = 0;
+
+  - interval: 2s
+    then:
+      - lambda: |-
+          static bool was_running = false;
+          bool is_running = id(compressor_running).state;
+
+          if (!was_running && is_running) {
+            id(compressor_start_count) += 1;
+          }
+
+          was_running = is_running;


### PR DESCRIPTION
Frequent compressor start-stop cycles are one of the key factors contributing to wear and reduced lifespan of a heat pump system. Each start requires a surge of electrical power and mechanical effort, generating stress on components like the compressor motor and valves.

By tracking the number of starts per hour:

You can detect short-cycling behavior, which often indicates incorrect control logic, oversized equipment, or insufficient system buffering.

It helps optimize performance and reliability, allowing for smarter automation or control adjustments to reduce wear.

 Historical data can highlight trends, such as increased start frequency over time, which may point to deteriorating system efficiency or upcoming maintenance needs.

In short: fewer, longer cycles are usually healthier for your compressor. Monitoring this value is a proactive step toward energy efficiency and system longevity.