### PR TITLE
Adjust pressure sensor to comply with ESPHome HA integration

### DIFF
--- a/heatpump.yaml
+++ b/heatpump.yaml
@@ -605,7 +605,7 @@ sensor:
     register_type: holding
     address: 0x74
     value_type: U_WORD
-    unit_of_measurement: kPA
+    unit_of_measurement: kPa
     device_class: "pressure"
     state_class: "measurement"
   # Register: 117
@@ -617,7 +617,7 @@ sensor:
     register_type: holding
     address: 0x75
     value_type: U_WORD
-    unit_of_measurement: kPA
+    unit_of_measurement: kPa
     device_class: "pressure"
     state_class: "measurement"
   # Register: 118


### PR DESCRIPTION
Adjust the pressure unit name so following warrning is no longer genrated.

> Entity sensor.heatpump_outdoor_unit_high_pressure (<class 'homeassistant.components.esphome.sensor.EsphomeSensor'>) is using native unit of measurement 'kPA' which is not a valid unit for the device class ('pressure') it is using; expected one of ['inHg', 'hPa', 'Pa', 'psi', 'kPa', 'mmHg', 'cbar', 'mbar', 'bar']; 